### PR TITLE
修改符号对照表

### DIFF
--- a/chapters/abstract.tex
+++ b/chapters/abstract.tex
@@ -22,17 +22,17 @@ The format of the English Abstract is what follows: Times New Roman, Small 4, ju
 \XDUpremainmatter
 
 \begin{symbollist}
-\item [符号] \hspace{12em} {符号名称}
-\item [$\in$]\hspace{12.5em} {属于}
-\item [$\mathbb{R}$]\hspace{12.5em} {实数集}
-\item [$w$] \hspace{12.5em} {权重}
-\item [$x$] \hspace{12.5em} {样本}
-\item [$y$] \hspace{12.5em} {标签}
-\item [$M$] \hspace{12.5em} {特征维数}
-\item [$N$] \hspace{12.5em} {样本数量}
-\item [$\eta$] \hspace{12.5em} {学习率}
-\item [$\mathcal{F}^{-1}$] \hspace{12.5em} {逆傅里叶变换}
-\item [$\gamma$] \hspace{12.5em} {弱分类器更新率}
+\item  \makebox [18em][l] {符号              } \makebox [16em][l] {符号名称}
+\item  \makebox [18em][l] {$\in$             } \makebox [16em][l] {属于}
+\item  \makebox [18em][l] {$\mathbb{R}$      } \makebox [16em][l] {实数集}
+\item  \makebox [18em][l] {$w$               } \makebox [16em][l] {权重}
+\item  \makebox [18em][l] {$x$               } \makebox [16em][l] {样本}
+\item  \makebox [18em][l] {$y$               } \makebox [16em][l] {标签}
+\item  \makebox [18em][l] {$M$               } \makebox [16em][l] {特征维数}
+\item  \makebox [18em][l] {$N$               } \makebox [16em][l] {样本数量}
+\item  \makebox [18em][l] {$\eta$            } \makebox [16em][l] {学习率}
+\item  \makebox [18em][l] {$\mathcal{F}^{-1}$} \makebox [16em][l] {逆傅里叶变换}
+\item  \makebox [18em][l] {$\gamma$          } \makebox [16em][l] {弱分类器更新率}
 \end{symbollist}
 
 \begin{abbreviationlist}


### PR DESCRIPTION
参考 [103yiran/XDUthesis_xelatex](https://github.com/103yiran/XDUthesis_xelatex) 中的格式，调整符号对照表格式如下：
![image](https://user-images.githubusercontent.com/22870372/80166952-c96ab100-8611-11ea-8293-b7cc2cdfa6e8.png)


注：原格式如下：
![image](https://user-images.githubusercontent.com/22870372/80165868-1731ea00-860f-11ea-9e92-19ddef121cf8.png)
